### PR TITLE
Add icon color props

### DIFF
--- a/demo-app/src/Generator.tsx
+++ b/demo-app/src/Generator.tsx
@@ -29,7 +29,7 @@ export function generator(): NodeProps[] {
         },
         {text: 'Parent 2 - Not expanded', state: {expanded: false, checked: false},
             nodes: [
-                {text: 'Child 1 - Custom Icon', icon: 'fa fa-stop fa-fw'},
+                {text: 'Child 1 - Custom Icon', icon: 'fa fa-stop'},
                 {text: 'Child 2 - No icon specified', classes: 'custom-class'},
                 {text: 'Child 3 - Image icon', image: 'https://www.wpsuperstars.net/wp-content/uploads/2015/01/59.png'}
             ]
@@ -40,6 +40,17 @@ export function generator(): NodeProps[] {
                 {text: 'Child 1 - Has checkbox - checked', state: {checked: true}},
                 {text: 'Child 2 - Has checkbox - unchecked', attr: {'data-random': 'random'}}
             ]
-        }
+        },
+        {text: 'Parent 4 - Changed icon colors',
+            nodes: [
+                {text: 'Child 1 - Changed icon color',
+                    icon: 'fa fa-circle ', iconColor: 'rgba(255,100,0,1)'},
+                {text: 'Child 2 - Changed background color',
+                    icon: 'fa fa-circle', iconBackground: '#9800ff'},
+                {text: 'Child 3 - Changed both colors',
+                    icon: 'fa fa-circle', iconColor: 'red', iconBackground: '#0d21ba'},
+                {text: 'Child 4 - Changed background color - with transparency',
+                    icon: 'fa fa-circle', iconBackground: 'rgba(0,0,0,0.5'},
+            ]}
     ];
 }

--- a/demo-app/src/components/Node.tsx
+++ b/demo-app/src/components/Node.tsx
@@ -182,7 +182,7 @@ export class Node extends React.Component<NodeProps, {}> {
             } else if ( this.props.icon ) {
                 icon = <i className={'Icon ' + this.props.icon} style={iconStyle}/>;
             } else {
-                icon = <i className={'Icon ' + this.props.parentData.nodeIcon}/>;
+                icon = <i className={'Icon ' + this.props.parentData.nodeIcon} style={iconStyle}/>;
             }
         }
 

--- a/demo-app/src/components/Node.tsx
+++ b/demo-app/src/components/Node.tsx
@@ -75,6 +75,8 @@ export interface NodeProps {
 
     // Styling
     icon?: string;
+    iconColor?: string;
+    iconBackground?: string;
     image?: string;
     classes?: string;
 
@@ -164,12 +166,23 @@ export class Node extends React.Component<NodeProps, {}> {
         // Icon
         let icon: JSX.Element = null;
         if ( this.props.parentData.showIcon ) {
+
+            let iconStyle: {color?: string, backgroundColor?: string} = {};
+
+            if ( this.props.iconColor ) {
+                iconStyle.color = this.props.iconColor;
+            }
+
+            if ( this.props.iconBackground ) {
+                iconStyle.backgroundColor = this.props.iconBackground;
+            }
+
             if ( this.props.parentData.showImage && this.props.image ) {
                 icon = <img className={'NodeIconImage'} src={this.props.image}/>;
             } else if ( this.props.icon ) {
-                icon = <i className={this.props.icon}/>;
+                icon = <i className={'Icon ' + this.props.icon} style={iconStyle}/>;
             } else {
-                icon = <i className={this.props.parentData.nodeIcon}/>;
+                icon = <i className={'Icon ' + this.props.parentData.nodeIcon}/>;
             }
         }
 
@@ -320,6 +333,8 @@ Node.defaultProps = {
 
     // Styling
     icon: null,
+    iconColor: null,
+    iconBackground: null,
     image: null,
     classes: '',
 

--- a/demo-app/src/components/Tree.css
+++ b/demo-app/src/components/Tree.css
@@ -5,8 +5,10 @@ li {
     margin-left: 18px;
 }
 .Icon {
-    width: 14px;
-    margin: 2px;
+    padding: 2px 4px;
+    margin-right: 2px;
+    box-sizing: border-box;
+    margin-top: 2px;
 }
 .NodeIconImage {
     width: 14px;

--- a/demo-app/src/components/Tree.tsx
+++ b/demo-app/src/components/Tree.tsx
@@ -560,7 +560,7 @@ Tree.defaultProps = {
     // Icons
     showIcon: true,
     showImage: true,
-    nodeIcon: 'fa fa-ban fa-fw',
+    nodeIcon: 'fa fa-ban',
     checkedIcon: 'fa fa-check-square',
     uncheckedIcon: 'fa fa-square-o',
     partiallyCheckedIcon: 'fa fa-square',

--- a/demo-app/src/components/Tree.tsx
+++ b/demo-app/src/components/Tree.tsx
@@ -66,7 +66,7 @@ export class Tree extends React.Component<TreeProps, TreeState> {
      * This structure contains all the data that nodes need from the
      * tree component root like settings and callback functions.
      */
-    private parentData: ParentData;
+    private readonly parentData: ParentData;
 
     /**
      * Indicates if there is a node currently selected and which one.
@@ -78,7 +78,7 @@ export class Tree extends React.Component<TreeProps, TreeState> {
     /**
      * Generates the IDs and states for all nodes recursively.
      * The IDs are crucial for the tree to work.
-     * The state is needed to avoid not defined expections.
+     * The state is needed to avoid not defined exceptions.
      *
      * @param {NodeProps[]} tree The tree to fill the IDs up.
      * @param {string} parentID The parent nodeId of the current nodes. For root left this param out.
@@ -122,7 +122,7 @@ export class Tree extends React.Component<TreeProps, TreeState> {
      * @param searchString The string to search for.
      * @return string[] Array of ID's where the string is present.
      */
-    public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string) {
+    public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string): string[] {
         let findInID: string[] = [];
 
         if ( !nodeID ) {

--- a/readme.md
+++ b/readme.md
@@ -185,13 +185,47 @@ classes?: string;                   // < Custom classes for the node.
 ## Additional options
 The tree provides additional static methods over the data. In this section they are listed and explained.
 
-### Search
+### Initialize the tree
+This function assigns node ids and initializes `state` object which are necessary fo the tree to work.
+You can use it as `initializedTree = Tree.initTree(notInitializedTree);`.
+
+```typescript
+/**
+ * Generates the IDs and states for all nodes recursively.
+ * The IDs are crucial for the tree to work.
+ * The state is needed to avoid not defined exceptions.
+ *
+ * @param {NodeProps[]} tree The tree to fill the IDs up.
+ * @param {string} parentID The parent nodeId of the current nodes. For root left this param out.
+ * @returns {NodeProps[]} The new filled tree.
+ */
+public static initTree(tree: NodeProps[], parentID: string = ''): NodeProps[]
+```
+
+### Select node by id
+This function can be used if the tree was initialised with the `initTree` function or the ids are assigned identically.
+(The id format: 0.5.1 -> The number of the node (starting from zero), where children are divided from its parents by a dot)
+The function is pretty fast and works in a following way:
+```typescript
+/**
+ * Searches for the node by nodeId, and returns it.
+ * Search is done by walking the tree by index numbers got form the nodeId.
+ *
+ * @param {NodeProps[]} tree The tree which to look in the node for.
+ * @param {string} nodeId The nodeId of the searched node.
+ * @returns {NodeProps}
+ * @warning Doesn't checks the validity of the nodeId.
+ */
+public static nodeSelector(tree: NodeProps[], nodeId: string): NodeProps
+```
+
+### Search by attribute name and string
 To use this function there should be `data-*` attributes passed to the nodes. This can be done on node basis as the following:
 `{text: 'Node with data attribute', attr: {'data-random': 'random'}}`. These attributes are appearing in HTML and can be used
 to search for a node or nodes with the same attributes.
 
 The function for searching can be called as: `Tree.nodeSearch(tree, nodeId, attributeName, attributeValue)` where
-```typescrypt
+```typescript
 /**
  * Searches trough the tree or subtree in attr field for the given string.
  * Only works if the nodeSelector can be applied on the tree.
@@ -202,6 +236,100 @@ The function for searching can be called as: `Tree.nodeSearch(tree, nodeId, attr
  * @param searchString The string to search for.
  * @return string[] Array of ID's where the string is present.
  */
-public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string)
+public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string): string[]
 ```
 And you get back an array of node IDs where the attribute has the specified value.
+
+### Other helper methods:
+These methods helps to change data in the tree when an event occurred in the tree.
+
+#### Helper: Node updater
+
+```typescript
+    /**
+     * Updates the given node's reference in the tree.
+     *
+     * @param {NodeProps[]} tree Where the node will be updated.
+     * @param {NodeProps} node The node to put reference in the tree.
+     * @warning Doesn't checks the validity of the node's nodeId.
+     */
+    public static nodeUpdater(tree: NodeProps[], node: NodeProps): NodeProps[]
+```
+
+#### Helper: Node checker
+
+```typescript
+    /**
+     * Helper function: Checks the node.
+     *
+     * @param {NodeProps} node The node to change.
+     * @param {boolean} value The new value of the checked field.
+     * @returns {NodeProps} The changed node.
+     */
+    public static nodeChecked(node: NodeProps, value: boolean): NodeProps
+```
+
+#### Helper: Node expander or collapser
+
+```typescript
+    /**
+     * Helper function: Expands or collapses the node.
+     *
+     * @param {NodeProps} node The node to change.
+     * @param {boolean} value The new value of the expanded field.
+     * @returns {NodeProps} The changed node.
+     */
+    public static nodeExpanded(node: NodeProps, value: boolean): NodeProps
+```
+
+#### Helper: Node enabler/disabler
+
+```typescript
+    /**
+     * Helper function: Disables or enables the node.
+     *
+     * @param {NodeProps} node The node to change.
+     * @param {boolean} value The new value of the disabled field.
+     * @returns {NodeProps} The changed node.
+     */
+    public static nodeDisabled(node: NodeProps, value: boolean): NodeProps
+```
+
+#### Helper: Node select changer
+
+```typescript
+    /**
+     * Helper function: Selects or deselects the node.
+     *
+     * @param {NodeProps} node The node to change.
+     * @param {boolean} value The new value of the selected field.
+     * @returns {NodeProps} The changed node.
+     */
+    public static nodeSelected(node: NodeProps, value: boolean): NodeProps
+```
+
+#### Helper: Node children updater
+
+```typescript
+    /**
+     * Helper function: Updates the children of the node.
+     *
+     * @param {NodeProps} node The node to change.
+     * @param {boolean} nodes The new children of the node.
+     * @returns {NodeProps} The changed node.
+     */
+    public static nodeChildren(node: NodeProps, nodes: NodeProps[]): NodeProps
+```
+
+#### Helper: Node loading state update
+
+```typescript
+    /**
+     * Helper function: Updates the loading state of the node.
+     *
+     * @param {NodeProps} node The node to change.
+     * @param {boolean} value The new loading value.
+     * @returns {NodeProps} The changed node.
+     */
+    public static nodeLoading(node: NodeProps, value: boolean): NodeProps
+```

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ To use the Wooden Tree two requirements must met.
 ## Install
 The component can be installed with `npm`:
 ```bash
-npm install -save react-wooden-tree
+npm install --save react-wooden-tree
 ```
 
 or you can download manually from this repository.
@@ -172,8 +172,36 @@ selectedIcon?: string;              // < Sets the selected icon for the node.
 lazyLoad?: boolean;                 // < Determines if the node calls the lazy loading function on expand.
 loading?: boolean;                  // < Determines if the node is currently loading: Null when error occurred
 
+attr?: {[key: string]: string};     // < The passed attributes which appear in HTML as well and are searchable.
+
 // Styling
 icon?: string;                      // < Custom icon for the node.
+iconColor?: string;                 // < The color of the custom icon.
+iconBackground?: string;            // < The background color of the custom icon.
 image?: string;                     // < Custom image for the node - preferred over the icon.
 classes?: string;                   // < Custom classes for the node.
 ```
+
+## Additional options
+The tree provides additional static methods over the data. In this section they are listed and explained.
+
+### Search
+To use this function there should be `data-*` attributes passed to the nodes. This can be done on node basis as the following:
+`{text: 'Node with data attribute', attr: {'data-random': 'random'}}`. These attributes are appearing in HTML and can be used
+to search for a node or nodes with the same attributes.
+
+The function for searching can be called as: `Tree.nodeSearch(tree, nodeId, attributeName, attributeValue)` where
+```typescrypt
+/**
+ * Searches trough the tree or subtree in attr field for the given string.
+ * Only works if the nodeSelector can be applied on the tree.
+ *
+ * @param {NodeProps[]} tree The tree in which the function will search.
+ * @param nodeID The id of the parent node (pass null if want to search the whole tree).
+ * @param attrName The name of the attribute to search in.
+ * @param searchString The string to search for.
+ * @return string[] Array of ID's where the string is present.
+ */
+public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string)
+```
+And you get back an array of node IDs where the attribute has the specified value.

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -75,6 +75,8 @@ export interface NodeProps {
 
     // Styling
     icon?: string;
+    iconColor?: string;
+    iconBackground?: string;
     image?: string;
     classes?: string;
 
@@ -164,12 +166,23 @@ export class Node extends React.Component<NodeProps, {}> {
         // Icon
         let icon: JSX.Element = null;
         if ( this.props.parentData.showIcon ) {
+
+            let iconStyle: {color?: string, backgroundColor?: string} = {};
+
+            if ( this.props.iconColor ) {
+                iconStyle.color = this.props.iconColor;
+            }
+
+            if ( this.props.iconBackground ) {
+                iconStyle.backgroundColor = this.props.iconBackground;
+            }
+
             if ( this.props.parentData.showImage && this.props.image ) {
                 icon = <img className={'NodeIconImage'} src={this.props.image}/>;
             } else if ( this.props.icon ) {
-                icon = <i className={this.props.icon}/>;
+                icon = <i className={'Icon ' + this.props.icon} style={iconStyle}/>;
             } else {
-                icon = <i className={this.props.parentData.nodeIcon}/>;
+                icon = <i className={'Icon ' + this.props.parentData.nodeIcon} style={iconStyle}/>;
             }
         }
 
@@ -320,6 +333,8 @@ Node.defaultProps = {
 
     // Styling
     icon: null,
+    iconColor: null,
+    iconBackground: null,
     image: null,
     classes: '',
 

--- a/src/components/Tree.css
+++ b/src/components/Tree.css
@@ -5,8 +5,10 @@ li {
     margin-left: 18px;
 }
 .Icon {
-    width: 14px;
-    margin: 2px;
+    padding: 2px 4px;
+    margin-right: 2px;
+    box-sizing: border-box;
+    margin-top: 2px;
 }
 .NodeIconImage {
     width: 14px;

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -560,7 +560,7 @@ Tree.defaultProps = {
     // Icons
     showIcon: true,
     showImage: true,
-    nodeIcon: 'fa fa-ban fa-fw',
+    nodeIcon: 'fa fa-ban',
     checkedIcon: 'fa fa-check-square',
     uncheckedIcon: 'fa fa-square-o',
     partiallyCheckedIcon: 'fa fa-square',

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -66,7 +66,7 @@ export class Tree extends React.Component<TreeProps, TreeState> {
      * This structure contains all the data that nodes need from the
      * tree component root like settings and callback functions.
      */
-    private parentData: ParentData;
+    private readonly parentData: ParentData;
 
     /**
      * Indicates if there is a node currently selected and which one.
@@ -78,7 +78,7 @@ export class Tree extends React.Component<TreeProps, TreeState> {
     /**
      * Generates the IDs and states for all nodes recursively.
      * The IDs are crucial for the tree to work.
-     * The state is needed to avoid not defined expections.
+     * The state is needed to avoid not defined exceptions.
      *
      * @param {NodeProps[]} tree The tree to fill the IDs up.
      * @param {string} parentID The parent nodeId of the current nodes. For root left this param out.
@@ -122,7 +122,7 @@ export class Tree extends React.Component<TreeProps, TreeState> {
      * @param searchString The string to search for.
      * @return string[] Array of ID's where the string is present.
      */
-    public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string) {
+    public static nodeSearch(tree: NodeProps[], nodeID: string, attrName: string, searchString: string): string[] {
         let findInID: string[] = [];
 
         if ( !nodeID ) {

--- a/src/tests/Node.test.tsx
+++ b/src/tests/Node.test.tsx
@@ -10,8 +10,8 @@ const initState = {
     checked: false
 };
 const subNodes = [
-    {text: 'Sub Node 0', id: '0.0'},
-    {text: 'Sub Node 1', id: '0.1'}
+    {text: 'Sub Node 0', nodeId: '0.0'},
+    {text: 'Sub Node 1', nodeId: '0.1'}
 ];
 
 beforeEach(() => {
@@ -22,7 +22,7 @@ beforeEach(() => {
         selectOnChange: null,
         onLazyLoad: null,
         showCheckbox: true,
-        initSelectedNode: function(id: string) {},
+        initSelectedNode: function(nodeId: string) {},
 
         // Icons
         showIcon: true,
@@ -52,7 +52,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
             />)
             .toJSON();
@@ -64,7 +64,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, expanded: true}}
                 nodes={null}
             />)
@@ -77,7 +77,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={{...parentData, checkboxFirst: false}}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
             />)
             .toJSON();
@@ -89,7 +89,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, expanded: true}}
                 nodes={subNodes}
             />)
@@ -102,7 +102,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 nodes={subNodes}
             />)
@@ -115,7 +115,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, expanded: true}}
                 nodes={subNodes}
             />)
@@ -128,7 +128,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, selected: true}}
                 selectedIcon={'icon icon-selected'}
             />)
@@ -141,7 +141,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={{...parentData, showCheckbox: false, showIcon: false}}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 hideCheckbox={true}
             />)
@@ -154,7 +154,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={{...parentData, showCheckbox: true, showIcon: true}}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 hideCheckbox={true}
                 icon={'fa fa-custom-icon'}
@@ -168,7 +168,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={{...parentData, showCheckbox: true, showIcon: true}}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 hideCheckbox={true}
                 icon={'fa fa-custom-icon'}
@@ -183,7 +183,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 loading={true}
                 lazyLoad={true}
@@ -197,7 +197,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 loading={null}
                 lazyLoad={true}
@@ -211,7 +211,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={initState}
                 classes={'custom-class'}
             />)
@@ -224,7 +224,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, selected: true}}
             />)
             .toJSON();
@@ -236,7 +236,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, checked: null}}
             />)
             .toJSON();
@@ -248,7 +248,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, checked: undefined}}
             />)
             .toJSON();
@@ -260,7 +260,7 @@ describe('node', () => {
             .create(<Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, checked: false}}
             />);
 
@@ -269,11 +269,65 @@ describe('node', () => {
             <Node
                 text={'Rendered Node'}
                 parentData={parentData}
-                id={'0'}
+                nodeId={'0'}
                 state={{...initState, checked: true}}
             />
         );
 
         expect(node.toJSON()).toMatchSnapshot();
+    });
+
+    it('should color the node icon with hex color', () => {
+        const node = renderer
+            .create(<Node
+                text={'Rendered Node'}
+                parentData={parentData}
+                nodeId={'0'}
+                state={initState}
+                icon={'fa fa-circle'}
+                iconColor={'#F5F5F5'}
+            />);
+        expect(node.toJSON()).toMatchSnapshot();
+    });
+
+    it('should recolor the node icon background with rgb color', () => {
+        const node = renderer
+            .create(<Node
+                text={'Rendered Node'}
+                parentData={parentData}
+                nodeId={'0'}
+                state={initState}
+                icon={'fa fa-circle'}
+                iconBackground={'rgb(100,255,100)'}
+            />);
+        expect(node.toJSON()).toMatchSnapshot();
+    });
+
+    it('should recolor both node icon ad icon background with color names', () => {
+        const node = renderer
+            .create(<Node
+                text={'Rendered Node'}
+                parentData={parentData}
+                nodeId={'0'}
+                state={initState}
+                icon={'fa fa-circle'}
+                iconColor={'red'}
+                iconBackground={'green'}
+            />);
+        expect(node.toJSON()).toMatchSnapshot();
+    });
+
+    it('should recolor the default icon color and background with rgba colors', () => {
+        const node = renderer
+            .create(<Node
+                text={'Rendered Node'}
+                parentData={parentData}
+                nodeId={'0'}
+                state={initState}
+                iconColor={'rgba(10,10,10,0.5)'}
+                iconBackground={'rgba(90,60,90,1)'}
+            />);
+        expect(node.toJSON()).toMatchSnapshot();
+
     });
 });

--- a/src/tests/Tree.test.tsx
+++ b/src/tests/Tree.test.tsx
@@ -138,11 +138,11 @@ beforeEach(() => {
                 {text: 'Child 0.0'},
                 {text: 'Child 0.1',
                     nodes: [
-                        {text: 'Child 0.1.0'}
+                        {text: 'Child 0.1.0', attr: {'data-info': 'search2', 'data-desc': 'searchDescExtended'}}
                     ]},
-                {text: 'Child 0.2'}
+                {text: 'Child 0.2', attr: {'data-info': 'search1', 'data-desc': 'searchDesc'}}
             ]},
-        {text: 'Parent 1', state: {selected: true}}
+        {text: 'Parent 1', state: {selected: true}, attr: {'data-info': 'search1', 'data-desc': 'searchDesc'}}
     ];
 
     subTree = [
@@ -202,12 +202,25 @@ describe('tree public method', () => {
         expect(tree[1].state).toMatchObject({...initState, selected: true});
     });
 
-    it('should return the correct node', () => {
+    it('should return the correct node by id', () => {
         let node = Tree.nodeSelector(tree, '0.2');
         expect(node.text).toBe('Child 0.2');
 
         node = Tree.nodeSelector(tree, '1');
         expect(node.text).toBe('Parent 1');
+    });
+
+    it('should return the correct node ids in the whole tree by attribute value', () => {
+        let ids = Tree.nodeSearch(tree, null, 'data-info', 'search1');
+        expect(ids.length).toBe(2);
+        expect(ids[0]).toBe('0.2');
+        expect(ids[1]).toBe('1');
+    });
+
+    it('should return the correct node ids in a subtree by attribute value', () => {
+        let ids = Tree.nodeSearch(tree, '0', 'data-info', 'search1');
+        expect(ids.length).toBe(1);
+        expect(ids[0]).toBe('0.2');
     });
 
     it('should update the tree correctly', () => {

--- a/src/tests/__snapshots__/Node.test.tsx.snap
+++ b/src/tests/__snapshots__/Node.test.tsx.snap
@@ -3,14 +3,40 @@
 exports[`node should add custom class 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable custom-class"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-square-o Icon CheckboxButton"
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
+  />
+  <span
+    onClick={[Function]}
+  >
+    Rendered Node
+  </span>
+</li>
+`;
+
+exports[`node should color the node icon with hex color 1`] = `
+<li
+  className="indent-0 NoOpenButton Selectable"
+  data-id="0"
+>
+  <i
+    className="fa fa-square-o Icon CheckboxButton"
+    onClick={[Function]}
+  />
+  <i
+    className="Icon fa fa-circle"
+    style={
+      Object {
+        "color": "#F5F5F5",
+      }
+    }
   />
   <span
     onClick={[Function]}
@@ -23,10 +49,11 @@ exports[`node should add custom class 1`] = `
 exports[`node should display custom icon 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
-    className="fa fa-custom-icon"
+    className="Icon fa fa-custom-icon"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -39,7 +66,7 @@ exports[`node should display custom icon 1`] = `
 exports[`node should display custom image as icon 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <img
     className="NodeIconImage"
@@ -56,7 +83,7 @@ exports[`node should display custom image as icon 1`] = `
 exports[`node should display error lazy loading icon 1`] = `
 <li
   className="indent-0 Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa-exclamation-triangle Icon ExpandButton"
@@ -67,7 +94,8 @@ exports[`node should display error lazy loading icon 1`] = `
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -80,7 +108,7 @@ exports[`node should display error lazy loading icon 1`] = `
 exports[`node should display loading icon 1`] = `
 <li
   className="indent-0 Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-spinner fa-spin Icon ExpandButton"
@@ -91,7 +119,8 @@ exports[`node should display loading icon 1`] = `
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -104,14 +133,15 @@ exports[`node should display loading icon 1`] = `
 exports[`node should display partially checked icon 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-square Icon CheckboxButton"
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -124,7 +154,7 @@ exports[`node should display partially checked icon 1`] = `
 exports[`node should display unique selected icon 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable selected"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-square-o Icon CheckboxButton"
@@ -134,7 +164,8 @@ exports[`node should display unique selected icon 1`] = `
     className="icon icon-selected"
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -147,14 +178,15 @@ exports[`node should display unique selected icon 1`] = `
 exports[`node should display warning icon when undefined 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-question-circle Icon CheckboxButton"
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -167,14 +199,15 @@ exports[`node should display warning icon when undefined 1`] = `
 exports[`node should indicate changed checked node (icon and class) 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable changed-checkbox"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-check-square Icon CheckboxButton"
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -187,7 +220,7 @@ exports[`node should indicate changed checked node (icon and class) 1`] = `
 exports[`node should indicate selected node (icon and class) 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable selected"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-square-o Icon CheckboxButton"
@@ -197,7 +230,8 @@ exports[`node should indicate selected node (icon and class) 1`] = `
     className="fa fa-check"
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -210,7 +244,7 @@ exports[`node should indicate selected node (icon and class) 1`] = `
 exports[`node should not display any icon (checkbox, icon, expand icon) 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <span
     onClick={[Function]}
@@ -223,7 +257,7 @@ exports[`node should not display any icon (checkbox, icon, expand icon) 1`] = `
 exports[`node should not render children nodes if collapsed 1`] = `
 <li
   className="indent-0 Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-angle-right Icon ExpandButton"
@@ -234,7 +268,85 @@ exports[`node should not render children nodes if collapsed 1`] = `
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
+  />
+  <span
+    onClick={[Function]}
+  >
+    Rendered Node
+  </span>
+</li>
+`;
+
+exports[`node should recolor both node icon ad icon background with color names 1`] = `
+<li
+  className="indent-0 NoOpenButton Selectable"
+  data-id="0"
+>
+  <i
+    className="fa fa-square-o Icon CheckboxButton"
+    onClick={[Function]}
+  />
+  <i
+    className="Icon fa fa-circle"
+    style={
+      Object {
+        "backgroundColor": "green",
+        "color": "red",
+      }
+    }
+  />
+  <span
+    onClick={[Function]}
+  >
+    Rendered Node
+  </span>
+</li>
+`;
+
+exports[`node should recolor the default icon color and background with rgba colors 1`] = `
+<li
+  className="indent-0 NoOpenButton Selectable"
+  data-id="0"
+>
+  <i
+    className="fa fa-square-o Icon CheckboxButton"
+    onClick={[Function]}
+  />
+  <i
+    className="Icon fa fa-ban fa-fw"
+    style={
+      Object {
+        "backgroundColor": "rgba(90,60,90,1)",
+        "color": "rgba(10,10,10,0.5)",
+      }
+    }
+  />
+  <span
+    onClick={[Function]}
+  >
+    Rendered Node
+  </span>
+</li>
+`;
+
+exports[`node should recolor the node icon background with rgb color 1`] = `
+<li
+  className="indent-0 NoOpenButton Selectable"
+  data-id="0"
+>
+  <i
+    className="fa fa-square-o Icon CheckboxButton"
+    onClick={[Function]}
+  />
+  <i
+    className="Icon fa fa-circle"
+    style={
+      Object {
+        "backgroundColor": "rgb(100,255,100)",
+      }
+    }
   />
   <span
     onClick={[Function]}
@@ -247,14 +359,15 @@ exports[`node should not render children nodes if collapsed 1`] = `
 exports[`node should render basic node 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-square-o Icon CheckboxButton"
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -268,7 +381,7 @@ exports[`node should render children nodes if expanded 1`] = `
 Array [
   <li
     className="indent-0 Selectable"
-    data-id=""
+    data-id="0"
 >
     <i
         className="fa fa-angle-down Icon ExpandButton"
@@ -279,7 +392,8 @@ Array [
         onClick={[Function]}
     />
     <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban fa-fw"
+        style={Object {}}
     />
     <span
         onClick={[Function]}
@@ -288,15 +402,16 @@ Array [
     </span>
 </li>,
   <li
-    className="indent-0 NoOpenButton Selectable"
-    data-id=""
+    className="indent-1 NoOpenButton Selectable"
+    data-id="0.0"
 >
     <i
         className="fa fa-square-o Icon CheckboxButton"
         onClick={[Function]}
     />
     <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban fa-fw"
+        style={Object {}}
     />
     <span
         onClick={[Function]}
@@ -305,15 +420,16 @@ Array [
     </span>
 </li>,
   <li
-    className="indent-0 NoOpenButton Selectable"
-    data-id=""
+    className="indent-1 NoOpenButton Selectable"
+    data-id="0.1"
 >
     <i
         className="fa fa-square-o Icon CheckboxButton"
         onClick={[Function]}
     />
     <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban fa-fw"
+        style={Object {}}
     />
     <span
         onClick={[Function]}
@@ -328,7 +444,7 @@ exports[`node should render expanded node with children 1`] = `
 Array [
   <li
     className="indent-0 Selectable"
-    data-id=""
+    data-id="0"
 >
     <i
         className="fa fa-angle-down Icon ExpandButton"
@@ -339,7 +455,8 @@ Array [
         onClick={[Function]}
     />
     <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban fa-fw"
+        style={Object {}}
     />
     <span
         onClick={[Function]}
@@ -348,15 +465,16 @@ Array [
     </span>
 </li>,
   <li
-    className="indent-0 NoOpenButton Selectable"
-    data-id=""
+    className="indent-1 NoOpenButton Selectable"
+    data-id="0.0"
 >
     <i
         className="fa fa-square-o Icon CheckboxButton"
         onClick={[Function]}
     />
     <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban fa-fw"
+        style={Object {}}
     />
     <span
         onClick={[Function]}
@@ -365,15 +483,16 @@ Array [
     </span>
 </li>,
   <li
-    className="indent-0 NoOpenButton Selectable"
-    data-id=""
+    className="indent-1 NoOpenButton Selectable"
+    data-id="0.1"
 >
     <i
         className="fa fa-square-o Icon CheckboxButton"
         onClick={[Function]}
     />
     <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban fa-fw"
+        style={Object {}}
     />
     <span
         onClick={[Function]}
@@ -387,14 +506,15 @@ Array [
 exports[`node should render not render empty children 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
     className="fa fa-square-o Icon CheckboxButton"
     onClick={[Function]}
   />
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <span
     onClick={[Function]}
@@ -407,10 +527,11 @@ exports[`node should render not render empty children 1`] = `
 exports[`node should render switched node and checkbox icon 1`] = `
 <li
   className="indent-0 NoOpenButton Selectable"
-  data-id=""
+  data-id="0"
 >
   <i
-    className="fa fa-ban fa-fw"
+    className="Icon fa fa-ban fa-fw"
+    style={Object {}}
   />
   <i
     className="fa fa-square-o Icon CheckboxButton"

--- a/src/tests/__snapshots__/Tree.test.tsx.snap
+++ b/src/tests/__snapshots__/Tree.test.tsx.snap
@@ -18,7 +18,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -39,7 +40,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -60,7 +62,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -80,7 +83,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         className="fa fa-check"
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -97,7 +101,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -114,7 +119,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -135,7 +141,8 @@ exports[`tree events should check parent if all children checked 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -164,7 +171,8 @@ exports[`tree events should match failed lazy load 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -181,7 +189,8 @@ exports[`tree events should match failed lazy load 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -198,7 +207,8 @@ exports[`tree events should match failed lazy load 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -214,7 +224,8 @@ exports[`tree events should match failed lazy load 1`] = `
         className="fa fa-check"
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -227,7 +238,8 @@ exports[`tree events should match failed lazy load 1`] = `
       data-id="1.0.1"
     >
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -240,7 +252,8 @@ exports[`tree events should match failed lazy load 1`] = `
       data-id="1.0.2"
     >
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -257,7 +270,8 @@ exports[`tree events should match failed lazy load 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -286,7 +300,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -303,7 +318,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -320,7 +336,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -336,7 +353,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
         className="fa fa-check"
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -349,7 +367,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
       data-id="1.0.1"
     >
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -362,7 +381,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
       data-id="1.0.2"
     >
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -379,7 +399,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -412,7 +433,8 @@ exports[`tree events should partially check parent if not all children checked 1
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -433,7 +455,8 @@ exports[`tree events should partially check parent if not all children checked 1
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -454,7 +477,8 @@ exports[`tree events should partially check parent if not all children checked 1
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -474,7 +498,8 @@ exports[`tree events should partially check parent if not all children checked 1
         className="fa fa-check"
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -491,7 +516,8 @@ exports[`tree events should partially check parent if not all children checked 1
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -508,7 +534,8 @@ exports[`tree events should partially check parent if not all children checked 1
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -529,7 +556,8 @@ exports[`tree events should partially check parent if not all children checked 1
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -562,7 +590,8 @@ exports[`tree events should partially check parent if not all children checked 2
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -583,7 +612,8 @@ exports[`tree events should partially check parent if not all children checked 2
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -604,7 +634,8 @@ exports[`tree events should partially check parent if not all children checked 2
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -624,7 +655,8 @@ exports[`tree events should partially check parent if not all children checked 2
         className="fa fa-check"
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -641,7 +673,8 @@ exports[`tree events should partially check parent if not all children checked 2
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -658,7 +691,8 @@ exports[`tree events should partially check parent if not all children checked 2
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}
@@ -679,7 +713,8 @@ exports[`tree events should partially check parent if not all children checked 2
         onClick={[Function]}
       />
       <i
-        className="fa fa-ban fa-fw"
+        className="Icon fa fa-ban"
+        style={Object {}}
       />
       <span
         onClick={[Function]}


### PR DESCRIPTION
The icon color and background added to node props to be able to modify it without passing css class.
The color accepts rgb, hex, or string colors as long as they are valid. Updated the tests and the readme to cover the new parts.

The picture bellow was generated by the following code:
```typescript
{text: 'Parent 4 - Changed icon colors',
    nodes: [
        {text: 'Child 1 - Changed icon color', icon: 'fa fa-circle ', iconColor: 'rgba(255,100,0,1)'},
        {text: 'Child 2 - Changed background color', icon: 'fa fa-circle', iconBackground: '#9800ff'},
        {text: 'Child 3 - Changed both colors', icon: 'fa fa-circle', iconColor: 'red', iconBackground: '#0d21ba'},
        {text: 'Child 4 - Changed background color - with transparency', icon: 'fa fa-circle', iconBackground: 'rgba(0,0,0,0.5'},
]}
```

![screenshot from 2018-10-10 14-03-36](https://user-images.githubusercontent.com/8531681/46735064-5c90ff80-cc95-11e8-8034-33c8c823aac1.png)

