### PR TITLE
feat(redux): Added checked_directly redux action

### DIFF
--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -482,6 +482,7 @@ export class Tree extends React.PureComponent<TreeProps, {}> {
      * @param {string} nodeId The element which checkbox was changed.
      */
     private handleCheckboxChange = (checked: boolean, nodeId: string): void => {
+        this.addCommandToQueue(nodeId, ActionTypes.CHECKED_DIRECTLY, checked);
         this.addCommandToQueue(nodeId, ActionTypes.CHECKED, checked);
 
         if ( this.props.hierarchicalCheck ) {

--- a/src/redux/types.tsx
+++ b/src/redux/types.tsx
@@ -17,6 +17,7 @@ export interface TreeState {
 export const ActionTypes = {
     EXPANDED: 'state.expanded',
     CHECKED: 'state.checked',
+    CHECKED_DIRECTLY: 'state.checked_directly',
     DISABLED: 'state.disabled',
     SELECTED: 'state.selected',
     CHILD_NODES: 'child_nodes',

--- a/src/tests/Tree.test.tsx
+++ b/src/tests/Tree.test.tsx
@@ -432,7 +432,7 @@ describe('tree events', () => {
 
         let check = childrenSelector(liSelector(node, '1'), 'check');
         check.props.onClick();
-        expect(changeCounter).toEqual(1);
+        expect(changeCounter).toEqual(2);
         expect(lastChange).toMatchObject(['1', 'state.checked', true]);
     });
 
@@ -452,7 +452,7 @@ describe('tree events', () => {
 
         let check = childrenSelector(liSelector(node, '1'), 'check');
         check.props.onClick();
-        expect(changeCounter).toEqual(6);
+        expect(changeCounter).toEqual(7);
 
         // Last change check
         expect(lastChange[1]).toMatch('state.checked');
@@ -475,7 +475,7 @@ describe('tree events', () => {
 
         let check = childrenSelector(liSelector(node, '1.0.0'), 'check');
         check.props.onClick();
-        expect(changeCounter).toEqual(3);
+        expect(changeCounter).toEqual(4);
 
         // Last change check
         expect(lastChange[1]).toMatch('state.checked');
@@ -513,7 +513,7 @@ describe('tree events', () => {
         check.props.onClick();
 
         // Check self, parent and two children + self, parent
-        expect(changeCounter).toEqual(7);
+        expect(changeCounter).toEqual(9);
 
         node.update(
             <Tree
@@ -560,7 +560,7 @@ describe('tree events', () => {
         check.props.onClick();
 
         // Check self, parent and two children
-        expect(changeCounter).toEqual(4);
+        expect(changeCounter).toEqual(6);
 
         node.update(
             <Tree


### PR DESCRIPTION
It is used to differentiate the clicked checkbox if wanted from
the ones which are checked because of the hierarchical check.
Closes #45.