### PR TITLE
Implemented basic accessibility using the keyboard

### DIFF
--- a/demo/src/Generator.tsx
+++ b/demo/src/Generator.tsx
@@ -1,4 +1,4 @@
-import { HierarchicalNodeProps, TreeDataType } from 'react-wooden-tree';
+import { HierarchicalNodeProps, TreeDataType } from '../../src/index';
 
 export function generator(): HierarchicalNodeProps[] {
     return [

--- a/src/components/CheckboxButton.tsx
+++ b/src/components/CheckboxButton.tsx
@@ -33,7 +33,12 @@ export class CheckboxButton extends React.Component<CheckboxButtonProps, {}> {
         let cName = icon + ' icon checkbox-button';
 
         return (
-            <i className={cName} onClick={() => this.props.onChange(switchVal)} />
+            <i
+                tabIndex={this.props.checkable ? 0 : -1}
+                className={cName}
+                onClick={() => this.props.onChange(switchVal)}
+                onKeyPress={() => this.props.onChange(switchVal)}
+            />
         );
     }
 }

--- a/src/components/ExpandButton.tsx
+++ b/src/components/ExpandButton.tsx
@@ -17,7 +17,12 @@ export class ExpandButton extends React.Component<ExpandButtonProps, {}> {
         let cName = icon + ' icon expand-button';
 
         return (
-            <i className={cName} onClick={() => this.props.onChange(!this.props.expanded)} />
+            <i
+                tabIndex={0}
+                className={cName}
+                onClick={() => this.props.onChange(!this.props.expanded)}
+                onKeyPress={() => this.props.onChange(!this.props.expanded)}
+            />
         );
     }
 }

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -67,6 +67,7 @@ export class Node extends React.PureComponent<NodeProps, {}> {
         const checkbox = !this.props.hideCheckbox && this.context.showCheckbox ? (
             <CheckboxButton
                 onChange={this.handleCheckChange}
+                checkable={this.props.checkable}
                 checked={this.props.state.checked}
                 checkedIcon={this.context.checkedIcon}
                 partiallyCheckedIcon={this.context.partiallyCheckedIcon}
@@ -169,7 +170,12 @@ export class Node extends React.PureComponent<NodeProps, {}> {
                     {icon1}
                     {selectedIcon}
                     {icon2}
-                    <span onClick={this.handleSelected} dangerouslySetInnerHTML={{ __html: this.props.text }} />
+                    <span
+                        tabIndex={this.props.selectable ? 0 : -1}
+                        onClick={this.handleSelected}
+                        onKeyPress={this.handleSelected}
+                        dangerouslySetInnerHTML={{ __html: this.props.text }}
+                    />
                 </li>
                 {sublist}
             </React.Fragment>

--- a/src/components/types.tsx
+++ b/src/components/types.tsx
@@ -232,6 +232,7 @@ export interface CheckboxButtonOnChangeType {
 export interface CheckboxButtonProps {
     onChange: (checked: boolean) => void;
     checked: boolean;
+    checkable: boolean;
     checkedIcon: string;
     partiallyCheckedIcon: string;
     uncheckedIcon: string;

--- a/src/tests/__snapshots__/Node.test.tsx.snap
+++ b/src/tests/__snapshots__/Node.test.tsx.snap
@@ -8,6 +8,8 @@ exports[`node should add custom class 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -20,6 +22,8 @@ exports[`node should add custom class 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -32,6 +36,8 @@ exports[`node should color the node icon with hex color 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-circle"
@@ -48,6 +54,8 @@ exports[`node should color the node icon with hex color 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -68,6 +76,8 @@ exports[`node should display custom icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -88,6 +98,8 @@ exports[`node should display custom image as icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -100,10 +112,14 @@ exports[`node should display error lazy loading icon 1`] = `
   <i
     className="fa-exclamation-triangle icon expand-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -116,6 +132,8 @@ exports[`node should display error lazy loading icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -128,10 +146,14 @@ exports[`node should display loading icon 1`] = `
   <i
     className="fa fa-spinner fa-spin icon expand-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -144,6 +166,8 @@ exports[`node should display loading icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -156,6 +180,8 @@ exports[`node should display partially checked icon 1`] = `
   <i
     className="fa fa-square icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -168,6 +194,8 @@ exports[`node should display partially checked icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -180,6 +208,8 @@ exports[`node should display unique selected icon 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon icon-selected"
@@ -195,6 +225,8 @@ exports[`node should display unique selected icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -207,6 +239,8 @@ exports[`node should display warning icon when undefined 1`] = `
   <i
     className="fa fa-question-circle icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -219,6 +253,8 @@ exports[`node should display warning icon when undefined 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -231,6 +267,8 @@ exports[`node should indicate changed checked node (icon and class) 1`] = `
   <i
     className="fa fa-check-square icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -243,6 +281,8 @@ exports[`node should indicate changed checked node (icon and class) 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -255,6 +295,8 @@ exports[`node should indicate selected node (icon and class) 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="fa fa-check"
@@ -270,6 +312,8 @@ exports[`node should indicate selected node (icon and class) 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -286,6 +330,8 @@ exports[`node should not display any icon (checkbox, icon, expand icon) 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -298,10 +344,14 @@ exports[`node should not render children nodes if collapsed 1`] = `
   <i
     className="fa fa-angle-right icon expand-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -314,6 +364,8 @@ exports[`node should not render children nodes if collapsed 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -326,6 +378,8 @@ exports[`node should not render empty children 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -338,6 +392,8 @@ exports[`node should not render empty children 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -350,6 +406,8 @@ exports[`node should recolor both node icon ad icon background with color names 
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-circle"
@@ -367,6 +425,8 @@ exports[`node should recolor both node icon ad icon background with color names 
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -379,6 +439,8 @@ exports[`node should recolor the default icon color and background with rgba col
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -396,6 +458,8 @@ exports[`node should recolor the default icon color and background with rgba col
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -408,6 +472,8 @@ exports[`node should recolor the node icon background with rgb color 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-circle"
@@ -424,6 +490,8 @@ exports[`node should recolor the node icon background with rgb color 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -436,6 +504,8 @@ exports[`node should render basic node 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <i
     className="icon fa fa-ban fa-fw"
@@ -448,6 +518,8 @@ exports[`node should render basic node 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;
@@ -461,10 +533,14 @@ Array [
     <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="icon fa fa-ban fa-fw"
@@ -477,6 +553,8 @@ Array [
               }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
 </li>,
   <li
@@ -486,6 +564,8 @@ Array [
     <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="icon fa fa-ban fa-fw"
@@ -498,6 +578,8 @@ Array [
               }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
 </li>,
   <li
@@ -507,6 +589,8 @@ Array [
     <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="icon fa fa-ban fa-fw"
@@ -519,6 +603,8 @@ Array [
               }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
 </li>,
 ]
@@ -533,10 +619,14 @@ Array [
     <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="icon fa fa-ban fa-fw"
@@ -549,6 +639,8 @@ Array [
               }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
 </li>,
   <li
@@ -558,6 +650,8 @@ Array [
     <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="icon fa fa-ban fa-fw"
@@ -570,6 +664,8 @@ Array [
               }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
 </li>,
   <li
@@ -579,6 +675,8 @@ Array [
     <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
     <i
         className="icon fa fa-ban fa-fw"
@@ -591,6 +689,8 @@ Array [
               }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
     />
 </li>,
 ]
@@ -608,6 +708,8 @@ exports[`node should render switched node and checkbox icon 1`] = `
   <i
     className="fa fa-square-o icon checkbox-button"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
   <span
     dangerouslySetInnerHTML={
@@ -616,6 +718,8 @@ exports[`node should render switched node and checkbox icon 1`] = `
       }
     }
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   />
 </li>
 `;

--- a/src/tests/__snapshots__/Tree.test.tsx.snap
+++ b/src/tests/__snapshots__/Tree.test.tsx.snap
@@ -12,10 +12,14 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -28,6 +32,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -37,10 +43,14 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -53,6 +63,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -62,10 +74,14 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -78,6 +94,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -87,6 +105,8 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-check"
@@ -102,6 +122,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -111,6 +133,8 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -123,6 +147,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -132,6 +158,8 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -144,6 +172,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -153,6 +183,8 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -165,6 +197,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -174,10 +208,14 @@ exports[`tree events should check parent if all children checked 1`] = `
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -190,6 +228,8 @@ exports[`tree events should check parent if all children checked 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
   </ul>
@@ -239,6 +279,8 @@ exports[`tree events should match failed lazy load 1`] = `
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -251,6 +293,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -260,6 +304,8 @@ exports[`tree events should match failed lazy load 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -272,6 +318,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -281,6 +329,8 @@ exports[`tree events should match failed lazy load 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -293,6 +343,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -313,6 +365,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -330,6 +384,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -347,6 +403,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -364,6 +422,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -373,6 +433,8 @@ exports[`tree events should match failed lazy load 1`] = `
       <i
         className="fa fa-exclamation icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -385,6 +447,8 @@ exports[`tree events should match failed lazy load 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
   </ul>
@@ -434,6 +498,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -446,6 +512,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -455,6 +523,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -467,6 +537,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -476,6 +548,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -488,6 +562,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -508,6 +584,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -525,6 +603,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -542,6 +622,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -559,6 +641,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -568,6 +652,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -580,6 +666,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -597,6 +685,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -614,6 +704,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -631,6 +723,8 @@ exports[`tree events should match lazy loaded nodes 1`] = `
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
   </ul>
@@ -680,10 +774,14 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -696,6 +794,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -705,10 +805,14 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -721,6 +825,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -730,10 +836,14 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -746,6 +856,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -755,6 +867,8 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-check"
@@ -770,6 +884,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -779,6 +895,8 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -791,6 +909,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -800,6 +920,8 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -812,6 +934,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -821,6 +945,8 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -833,6 +959,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -842,10 +970,14 @@ exports[`tree events should partially check parent if not all children checked 1
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -858,6 +990,8 @@ exports[`tree events should partially check parent if not all children checked 1
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
   </ul>
@@ -907,10 +1041,14 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -923,6 +1061,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -932,10 +1072,14 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -948,6 +1092,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -957,10 +1103,14 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-angle-down icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -973,6 +1123,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -982,6 +1134,8 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-check"
@@ -997,6 +1151,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -1006,6 +1162,8 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -1018,6 +1176,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -1027,6 +1187,8 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -1039,6 +1201,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -1048,6 +1212,8 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-check-square icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -1060,6 +1226,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
     <li
@@ -1069,10 +1237,14 @@ exports[`tree events should partially check parent if not all children checked 2
       <i
         className="fa fa-angle-right icon expand-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="fa fa-square-o icon checkbox-button"
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
       <i
         className="icon fa fa-ban"
@@ -1085,6 +1257,8 @@ exports[`tree events should partially check parent if not all children checked 2
           }
         }
         onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       />
     </li>
   </ul>


### PR DESCRIPTION
Selecting the node, checking checkboxes, expanding/collapsing nodes are now accessible via the keyboard.

I also fixed a path issue in the demo's generator as it was failing on an import.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7366